### PR TITLE
due to numpy upgrade: np.int -> int, np.float->float

### DIFF
--- a/examples.py
+++ b/examples.py
@@ -43,7 +43,7 @@ def apply_hfd(x,name=None):
 ### Higuchi original data: random Gaussian increments = Brownian
 N = 2**16
 z = np.random.randn(N+1000)
-x = np.empty(N,dtype=np.float)
+x = np.zeros(N)
 for i in range(N):
     x[i] = np.sum(z[:(i+1000)])
 

--- a/hfd.py
+++ b/hfd.py
@@ -37,7 +37,7 @@ def curve_length(X,opt=True,num_k=50,k_max=None):
     k_arr = interval_t(N,num_val=num_k,kmax=k_max)
 
     ### The average length
-    Lk = np.empty(k_arr.size,dtype=np.float)
+    Lk = np.zeros(k_arr.size)
 
     ### C library
     if opt:
@@ -121,7 +121,7 @@ def interval_t(size,num_val=50,kmax=None):
         k_stop = size//2
         print("Warning: k cannot be longer than N/2")
         
-    k = np.logspace(start=np.log2(2),stop=np.log2(k_stop),base=2,num=num_val,dtype=np.int)
+    k = np.logspace(start=np.log2(2),stop=np.log2(k_stop),base=2,num=num_val,dtype=int)
     return np.unique(k);
 
 def init_lib():


### PR DESCRIPTION
After Numpy 1.20, `numpy.int` and `numpy.float` will be deprecated. So there will be an error: `AttributeError: module 'numpy' has no attribute 'int'`. I changed all `np.empty(*,dtype=np.float)` to `np.zeros(*)` and all `np.int` to `int` to make this code compatible with a newer version of Numpy.